### PR TITLE
Fix real world usage of caniuse-db

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function getBrowserScope() {
 }
 
 var features = fs
-  .readdirSync("node_modules/caniuse-db/features-json")
+  .readdirSync(`${__dirname}/node_modules/caniuse-db/features-json`)
   .map((file) => file.replace(".json", ""))
 
 var parse = memoize(parseCaniuseData, function(feature, browsers) {


### PR DESCRIPTION
When you are in a project that use caniuse-api in `node_modules`, `caniuse-db` is in `node_modules/caniuse-api/node_modules/caniuse-db` and since fs use `process.cwd()` to resolve relative filename, this cannot really be tested automatically (since tests are run from caniuse-api folder.