### PR TITLE
Cleaner build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
 dist
-features.json
+src/features.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,4 @@
 
 # 0.0.1 - 2014-12-09
 
-✨Initial release
+✨ Initial release

--- a/bin/generate-features.js
+++ b/bin/generate-features.js
@@ -1,5 +1,5 @@
-import * as fs from "fs"
-import * as path from "path"
+import fs from "fs"
+import path from "path"
 
 var caniusePath = path.dirname(require.resolve("caniuse-db/package.json"))
 var featuresPath = path.join(caniusePath, "features-json")
@@ -7,4 +7,6 @@ var features = fs
   .readdirSync(featuresPath)
   .map((file) => file.replace(".json", ""))
 
-fs.writeFileSync(path.join(__dirname, "..", "features.json"), JSON.stringify(features, null, 2))
+var json = JSON.stringify(features, null, 2)
+
+process.stdout.write(`var features = ${json}\nexport default features`)

--- a/package.json
+++ b/package.json
@@ -14,19 +14,20 @@
     "lodash.uniq": "^2.4.1"
   },
   "devDependencies": {
-    "6to5": "^1.14.17",
+    "6to5": "^3.3.12",
     "jshint": "^2.5.10",
     "tap-spec": "^2.1.1",
     "tape": "^3.0.3"
   },
   "scripts": {
-    "build": "6to5 src --out-dir dist",
+    "build": "npm run build_features && npm run build_source",
+    "build_features": "6to5-node bin/generate-features.js > src/features.js",
+    "build_source": "6to5 src -d dist",
     "lint": "jshint src",
     "prepublish": "npm run build",
-    "pretest": "6to5-node src/generate-features.js",
-    "test": "npm run lint && 6to5-node test/*.js | tap-spec",
-    "postinstall": "[ -d dist ] && node dist/generate-features.js || true"
- },
+    "pretest": "npm run build_features",
+    "test": "npm run lint && 6to5-node test/all.js | tap-spec"
+  },
   "repository": "nyalab/caniuse-api",
   "keywords": [
     "caniuse",

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,23 @@
-import * as memoize from "lodash.memoize"
-import * as browserslist from "browserslist"
-
+import memoize from "lodash.memoize"
+import browserslist from "browserslist"
+import features from "./features.js"
 import {contains, parseCaniuseData, cleanBrowsersList} from "./utils"
-import * as features from "../features.json"
 
 var browsers
-function setBrowserScope(browserList) {
-  browsers = cleanBrowsersList(browserList)
+
+export function getBrowserScope() {
+  return browsers
 }
 
-function getBrowserScope() {
-  return browsers
+export function setBrowserScope(browserList) {
+  browsers = cleanBrowsersList(browserList)
 }
 
 var parse = memoize(parseCaniuseData, function(feature, browsers) {
   return feature.title + browsers
 })
 
-function getSupport(query) {
+export function getSupport(query) {
   let feature
   try {
     feature = require(`caniuse-db/features-json/${query}`)
@@ -29,7 +29,7 @@ function getSupport(query) {
   return parse(feature, browsers)
 }
 
-function isSupported(feature, browsers) {
+export function isSupported(feature, browsers) {
   let data
   try {
     data = require(`caniuse-db/features-json/${feature}`)
@@ -47,7 +47,7 @@ function isSupported(feature, browsers) {
     .every((browser) => data.stats[browser[0]][browser[1]] === "y")
 }
 
-function find(query) {
+export function find(query) {
   if (~features.indexOf(query)) { // exact match
     return query
   }
@@ -55,11 +55,8 @@ function find(query) {
   return features.filter((file) => contains(file, query))
 }
 
-function getLatestStableBrowsers() {
+export function getLatestStableBrowsers() {
   return browserslist.queries.lastVersions.select(1)
 }
 
 setBrowserScope()
-
-export {getSupport, isSupported, find, getLatestStableBrowsers, setBrowserScope, getBrowserScope}
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
-import * as uniq from "lodash.uniq"
-import * as browserslist from "browserslist"
+import uniq from "lodash.uniq"
+import browserslist from "browserslist"
 
 export function contains(str, substr) {
-  return !!~str.indexOf(substr)
+  return str != null && str.indexOf(substr) >= 0
 }
 
 export function parseCaniuseData(feature, browsers) {

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,3 @@
+import "./index"
+import "./utils"
+import "./features"

--- a/test/features.js
+++ b/test/features.js
@@ -1,8 +1,7 @@
-import * as test from "tape"
+import test from "tape"
+import features from "../src/features.js"
 
-test("features.json", function(t) {
-  var features = require("../features.json")
+test("features.js", function(t) {
   t.ok(features.indexOf("css-variables") > -1 && features.indexOf("css-sticky") > -1, "should contains some features keys")
-
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-import * as test from "tape"
-import * as browserslist from "browserslist"
+import test from "tape"
+import browserslist from "browserslist"
 import * as caniuse from "../src/index"
 import {cleanBrowsersList} from "../src/utils"
 
@@ -54,4 +54,3 @@ test("getSupport tests", (t) => {
   //wtf it is not working t.throws(caniuse.getSupport("canaillou"),"throws if silly thing are asked")
   t.end()
 })
-

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
-import * as test from "tape"
-import * as browserslist from "browserslist"
-import * as uniq from "lodash.uniq"
+import test from "tape"
+import browserslist from "browserslist"
+import uniq from "lodash.uniq"
 import {contains, parseCaniuseData, cleanBrowsersList} from "../src/utils"
 
 test("contains should work", (t) => {


### PR DESCRIPTION
* Cleaner imports
* Bump 6to5 to the last version
* Move `generate-features.js` to `bin/`
* Generate a JS instead of a JSON to included it to 6to5 build
* No windows compat trick (closes #22)