### PR TITLE
1.3.0 to enable in browser usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
 dist
-features.json
+features.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
+# http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+sudo: false
+
 language: node_js
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# 1.2.1
+# 1.3.0 - 2015-03-30
+
+- Added: better exception messages
+- Added: full browserify compatibility (by avoiding dynamic require)
+
+# 1.2.2 - 2015-02-06
+
+- Fixed: postinstall hook for Windows
+
+# 1.2.1 - 2015-02-04
 
 - Changed: Allow in browser usage by avoiding `require.resolve` and using a generated json instead or reading a directory ([#20](https://github.com/Nyalab/caniuse-api/pull/20)]
 

--- a/package.json
+++ b/package.json
@@ -15,17 +15,18 @@
     "shelljs": "^0.3.0"
   },
   "devDependencies": {
-    "6to5": "^1.14.17",
+    "babel": "^4.7.16",
+    "babel-tape-runner": "^1.0.0",
     "jshint": "^2.5.10",
     "tap-spec": "^2.1.1",
     "tape": "^3.0.3"
   },
   "scripts": {
-    "build": "6to5 src --out-dir dist",
+    "build": "babel src --out-dir dist",
     "lint": "jshint src",
     "prepublish": "npm run build",
-    "pretest": "6to5-node src/generate-features.js",
-    "test": "npm run lint && 6to5-node test/*.js | tap-spec",
+    "pretest": "babel-node src/generate-features.js",
+    "test": "npm run lint && babel-tape-runner test/*.js | tap-spec",
     "postinstall": "node -e \"require('shelljs/global');if(test('-d', 'dist'))exec('node dist/generate-features.js')\""
   },
   "repository": "nyalab/caniuse-api",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caniuse-api",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "request the caniuse data to check browsers compatibilities",
   "main": "dist/index.js",
   "files": [

--- a/src/generate-features.js
+++ b/src/generate-features.js
@@ -9,6 +9,6 @@ const features = fs
     )
   )
   .map(file => file.replace(".json", ""))
-  .map(feature => `"${feature}": require("${path.join("caniuse-db", "features-json", feature)}")`)
+  .map(feature => `"${feature}": function() { return require("${path.join("caniuse-db", "features-json", feature)}")}`)
 
 fs.writeFileSync(path.join(__dirname, "..", "features.js"), `module.exports = {${features.join(",\n")}}`)

--- a/src/generate-features.js
+++ b/src/generate-features.js
@@ -1,5 +1,5 @@
-import * as fs from "fs"
-import * as path from "path"
+import fs from "fs"
+import path from "path"
 
 var caniusePath = path.dirname(require.resolve("caniuse-db/package.json"))
 var featuresPath = path.join(caniusePath, "features-json")

--- a/src/generate-features.js
+++ b/src/generate-features.js
@@ -1,10 +1,14 @@
 import fs from "fs"
 import path from "path"
 
-var caniusePath = path.dirname(require.resolve("caniuse-db/package.json"))
-var featuresPath = path.join(caniusePath, "features-json")
-var features = fs
-  .readdirSync(featuresPath)
-  .map((file) => file.replace(".json", ""))
+const features = fs
+  .readdirSync(
+    path.join(
+      path.dirname(require.resolve("caniuse-db/package.json")),
+      "features-json"
+    )
+  )
+  .map(file => file.replace(".json", ""))
+  .map(feature => `"${feature}": require("${path.join("caniuse-db", "features-json", feature)}")`)
 
-fs.writeFileSync(path.join(__dirname, "..", "features.json"), JSON.stringify(features, null, 2))
+fs.writeFileSync(path.join(__dirname, "..", "features.js"), `module.exports = {${features.join(",\n")}}`)

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import memoize from "lodash.memoize"
 import browserslist from "browserslist"
 
 import {contains, parseCaniuseData, cleanBrowsersList} from "./utils"
-import features from "../features.json"
+import features from "../features"
+const featuresList = Object.keys(features)
 
 var browsers
 function setBrowserScope(browserList) {
@@ -20,7 +21,7 @@ var parse = memoize(parseCaniuseData, function(feature, browsers) {
 function getSupport(query) {
   let feature
   try {
-    feature = require(`caniuse-db/features-json/${query}`)
+    feature = features[query]
   } catch(e) {
     let res = find(query)
     if (res.length === 1) return getSupport(res[0])
@@ -32,11 +33,11 @@ function getSupport(query) {
 function isSupported(feature, browsers) {
   let data
   try {
-    data = require(`caniuse-db/features-json/${feature}`)
+    data = features[feature]
   } catch(e) {
     let res = find(feature)
     if (res.length === 1) {
-      data = require(`caniuse-db/features-json/${res[0]}`)
+      data = features[res[0]]
     } else {
       throw new ReferenceError(`Please provide a proper feature name. Cannot find ${feature}`)
     }
@@ -48,11 +49,11 @@ function isSupported(feature, browsers) {
 }
 
 function find(query) {
-  if (~features.indexOf(query)) { // exact match
+  if (~featuresList.indexOf(query)) { // exact match
     return query
   }
 
-  return features.filter((file) => contains(file, query))
+  return featuresList.filter((file) => contains(file, query))
 }
 
 function getLatestStableBrowsers() {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function getSupport(query) {
   } catch(e) {
     let res = find(query)
     if (res.length === 1) return getSupport(res[0])
-    throw new ReferenceError("Please provide a proper feature name")
+    throw new ReferenceError(`Please provide a proper feature name. Cannot find ${query}`)
   }
   return parse(feature, browsers)
 }
@@ -38,7 +38,7 @@ function isSupported(feature, browsers) {
     if (res.length === 1) {
       data = require(`caniuse-db/features-json/${res[0]}`)
     } else {
-      throw new ReferenceError("Please provide a proper feature name")
+      throw new ReferenceError(`Please provide a proper feature name. Cannot find ${feature}`)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ var parse = memoize(parseCaniuseData, function(feature, browsers) {
 function getSupport(query) {
   let feature
   try {
-    feature = features[query]
+    feature = features[query]()
   } catch(e) {
     let res = find(query)
     if (res.length === 1) return getSupport(res[0])
@@ -33,11 +33,11 @@ function getSupport(query) {
 function isSupported(feature, browsers) {
   let data
   try {
-    data = features[feature]
+    data = features[feature]()
   } catch(e) {
     let res = find(feature)
     if (res.length === 1) {
-      data = features[res[0]]
+      data = features[res[0]]()
     } else {
       throw new ReferenceError(`Please provide a proper feature name. Cannot find ${feature}`)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import * as memoize from "lodash.memoize"
-import * as browserslist from "browserslist"
+import memoize from "lodash.memoize"
+import browserslist from "browserslist"
 
 import {contains, parseCaniuseData, cleanBrowsersList} from "./utils"
-import * as features from "../features.json"
+import features from "../features.json"
 
 var browsers
 function setBrowserScope(browserList) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
-import * as uniq from "lodash.uniq"
-import * as browserslist from "browserslist"
+import uniq from "lodash.uniq"
+import browserslist from "browserslist"
 
 export function contains(str, substr) {
   return !!~str.indexOf(substr)

--- a/test/generate-features.js
+++ b/test/generate-features.js
@@ -1,8 +1,13 @@
 import test from "tape"
-
+import features from "../features"
+const featuresList = Object.keys(features)
 test("features.json", function(t) {
-  var features = require("../features.json")
-  t.ok(features.indexOf("css-variables") > -1 && features.indexOf("css-sticky") > -1, "should contains some features keys")
+  t.ok(
+    (
+      featuresList.indexOf("css-variables") > -1 &&
+      featuresList.indexOf("css-sticky") > -1
+    ),
+    "should contains some features keys")
 
   t.end()
 })

--- a/test/generate-features.js
+++ b/test/generate-features.js
@@ -1,4 +1,4 @@
-import * as test from "tape"
+import test from "tape"
 
 test("features.json", function(t) {
   var features = require("../features.json")

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-import * as test from "tape"
-import * as browserslist from "browserslist"
+import test from "tape"
+import browserslist from "browserslist"
 import * as caniuse from "../src/index"
 import {cleanBrowsersList} from "../src/utils"
 

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,8 @@ test("isSupported tests", (t) => {
 
 test("getSupport tests", (t) => {
   caniuse.setBrowserScope()
+
+  let borderRadiusFeature = require('caniuse-db/features-json/border-radius')
   let borderRadiusSupport = {
     safari: { y: 3.1, x: 4, '#1': 6.1 },
     opera: { n: 10, y: 10.5 },
@@ -47,7 +49,8 @@ test("getSupport tests", (t) => {
     chrome: { y: 4, x: 4 },
     android: { y: 2.1, x: 2.1 },
     and_uc: { y: 9.9 },
-    and_chr: { y: 40 }
+    // workaround for https://github.com/Nyalab/caniuse-api/issues/19
+    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) }
   }
 
   t.deepEqual(caniuse.getSupport("border-radius"), borderRadiusSupport, "border-radius support is ok")

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,7 +25,8 @@ test("parseCaniuseData should work", (t) => {
     chrome: { y: 4, x: 4 },
     android: { y: 2.1, x: 2.1 },
     and_uc: { y: 9.9 },
-    and_chr: { y: 40 }
+    // workaround for https://github.com/Nyalab/caniuse-api/issues/19
+    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) }
   }
 
   t.deepEqual(parseCaniuseData(borderRadiusFeature, browsers), correctSupport, "border-radius support is correct")

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
-import * as test from "tape"
-import * as browserslist from "browserslist"
-import * as uniq from "lodash.uniq"
+import test from "tape"
+import browserslist from "browserslist"
+import uniq from "lodash.uniq"
 import {contains, parseCaniuseData, cleanBrowsersList} from "../src/utils"
 
 test("contains should work", (t) => {


### PR DESCRIPTION
@Nyalab here is a proposal for 1.3.0

- Added: better exception messages
- 6to5 to babel (note the babel-tape-runner thing + lots of `import * as ` changes)
- Added: full browserify compatibility (by avoiding dynamic require)
- Optimisation for node: lazyload hardcoded require when needed.

If you are ok with that, just tell me so I can merge and release.
