### PR TITLE
Do not fail when browserslist gives a browser that caniuse-api doesn't know about

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function isSupported(feature, browsers) {
 
   return browserslist(browsers)
     .map((browser) => browser.split(" "))
-    .every((browser) => data.stats[browser[0]][browser[1]] === "y")
+    .every((browser) => data.stats[browser[0]] && data.stats[browser[0]][browser[1]] === "y")
 }
 
 function find(query) {

--- a/test/index.js
+++ b/test/index.js
@@ -41,7 +41,7 @@ test("getSupport tests", (t) => {
   let borderRadiusSupport = {
     safari: { y: 3.1, x: 4, '#1': 6.1 },
     opera: { n: 10, y: 10.5 },
-    op_mini: { n: 5 },
+    op_mini: {},
     ios_saf: { y: 3.2, x: 3.2 },
     ie_mob: { y: 10 },
     edge: { y: 12 },
@@ -51,7 +51,8 @@ test("getSupport tests", (t) => {
     android: { y: 2.1, x: 2.1 },
     and_uc: { y: 9.9 },
     // workaround for https://github.com/Nyalab/caniuse-api/issues/19
-    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) }
+    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) },
+    samsung: { y: 4 }
   }
 
   t.deepEqual(caniuse.getSupport("border-radius"), borderRadiusSupport, "border-radius support is ok")

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,23 @@ test("isSupported tests", (t) => {
   t.end()
 })
 
+// If for some reason the caniuse-db is not the same in browserslist and in caniuse-api
+// browserslist could return browsers that caniuse-api doesn't know about and crashes
+test("isSupported test with browsers caniuse doesn't know", (t) => {
+  browserslist.data.notabrowser = {
+    name: 'notabrowser',
+    versions: ['1'],
+    released: ['1']
+  };
+  browserslist.versionAliases.notabrowser = {}
+
+  t.notOk(caniuse.isSupported("border-radius", "notabrowser 1"), "do not throw on non existing data")
+
+  delete browserslist.data.notabrowser
+  delete browserslist.versionAliases.notabrowser
+  t.end()
+})
+
 test("getSupport tests", (t) => {
   caniuse.setBrowserScope()
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,7 @@ test("parseCaniuseData should work", (t) => {
   let correctSupport = {
     safari: { y: 3.1, x: 4, '#1': 6.1 },
     opera: { n: 10, y: 10.5 },
-    op_mini: { n: 5 },
+    op_mini: { },
     ios_saf: { y: 3.2, x: 3.2 },
     ie_mob: { y: 10 },
     ie: { n: 8, y: 9 },
@@ -27,7 +27,8 @@ test("parseCaniuseData should work", (t) => {
     android: { y: 2.1, x: 2.1 },
     and_uc: { y: 9.9 },
     // workaround for https://github.com/Nyalab/caniuse-api/issues/19
-    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) }
+    and_chr: { y: parseInt(Object.keys(borderRadiusFeature.stats.and_chr).filter(v => borderRadiusFeature.stats.and_chr[v] === "y").pop()) },
+    samsung: { y: 4 }
   }
 
   t.deepEqual(parseCaniuseData(borderRadiusFeature, browsers), correctSupport, "border-radius support is correct")


### PR DESCRIPTION
Hi,

I ran into a weird case this morning and could track down the source to the following scenario: 

browserslist and caniuse-api got a different version of caniuse-db, the one in browserslist being more recent and containing "samsung 4" as a browser.

caniuse-db didn't know about this browser and failed the lookup in `isSupported` with the following stacktrace: 
```
[16:29:43] TypeError: Cannot read property '4' of undefined
    at /work/foundation/sq-web-assets/sq-gulp/node_modules/postcss-cssnext/node_modules/caniuse-api/dist/index.js:79:34
    at Array.every (native)
    at isSupported (/work/foundation/sq-web-assets/sq-gulp/node_modules/postcss-cssnext/node_modules/caniuse-api/dist/index.js:77:6)
    at /work/foundation/sq-web-assets/sq-gulp/node_modules/postcss-cssnext/lib/index.js:74:117
    at Array.forEach (native)
```

I added a test to reproduce the case and added a fix as well.
If you have a recommendation on a cleaner test I can modify it.