### PR TITLE
Drop `shell-js`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "browserslist": "^1.0.1",
     "caniuse-db": "^1.0.30000346",
     "lodash.memoize": "^4.1.0",
-    "lodash.uniq": "^4.3.0",
-    "shelljs": "^0.7.0"
+    "lodash.uniq": "^4.3.0"
   },
   "devDependencies": {
     "babel": "^4.7.16",


### PR DESCRIPTION
Please correct me if I'm wrong, but it looks like it stopped being used with #47.