### PR TITLE
fix: isSupported when feature name is not in db

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function isSupported(feature, browsers) {
 
   return browserslist(browsers)
     .map((browser) => browser.split(" "))
-    .every((browser) => data.stats[browser[0]] && data.stats[browser[0]][browser[1]] === "y")
+    .every((browser) => data && data.stats[browser[0]] && data.stats[browser[0]][browser[1]] === "y")
 }
 
 function find(query) {


### PR DESCRIPTION
# Bug
when use
```js
isSupported('notTheCssName', 'chrome')
```
occur error : Cannot read property 'stats' of undefined

# break change
no