### PR TITLE
getLatestStableBrowsers returns array of all browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ function find(query) {
 }
 
 function getLatestStableBrowsers() {
-  return browserslist.queries.lastVersions.select(1)
+  return browserslist.queries.lastVersions.select(this, 1)
 }
 
 setBrowserScope()


### PR DESCRIPTION
-getLatestStableBrowsers calls select on browserslist internally which requires a context argument.
-Passing "this" as first argument to select and version as the second argument.
-browserslist select function reference https://github.com/ai/browserslist/blob/master/index.js#L470
-Fixes #56.